### PR TITLE
Fix #3: Test, Build, Sign and push to GH releases

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,75 @@
+name: Build & Publish Release APK
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build/Test APK
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: setup jdk
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Run Tests
+        run: cd obv_messenger/ && ./gradlew test --stacktrace
+
+      - name: Build Release APK
+        run: cd obv_messenger/ && ./gradlew assembleRelease --stacktrace
+
+      - name: Rename APK
+        run: mv obv_messenger/app/build/outputs/apk/prod/release/app-prod-release-unsigned.apk Olvid.apk
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: apk
+          path: Olvid.apk
+
+  release:
+    name: Sign/Release APK
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Download APK from build
+        uses: actions/download-artifact@v2
+        with:
+          name: apk
+
+      - name: setup jdk
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Sign APK
+        uses: r0adkll/sign-android-release@v1
+        id: sign_app
+        with:
+          releaseDirectory: .
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "32.0.0"
+
+      - name: Upload Release APK
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            Olvid.apk
+            ${{steps.sign_app.outputs.signedReleaseFile}}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,6 +60,13 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Setup build tool version variable
+        shell: bash
+        run: |
+          BUILD_TOOL_VERSION=$(ls /usr/local/lib/android/sdk/build-tools/ | tail -n 1)
+          echo "BUILD_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
+          echo Last build tool version is: $BUILD_TOOL_VERSION
+
       - name: Download APK from build
         uses: actions/download-artifact@v3
         with:
@@ -81,7 +88,7 @@ jobs:
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
         env:
-          BUILD_TOOLS_VERSION: "32.0.0"
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
       - name: 'Get Previous tag'
         id: previoustag

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,11 @@ on:
       - '*'
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        description: "The tag to use"
 
 jobs:
   build:
@@ -14,7 +19,9 @@ jobs:
     steps:
 
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: setup jdk
         uses: actions/setup-java@v2
@@ -43,9 +50,15 @@ jobs:
   release:
     name: Sign/Release APK
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(inputs.ref || github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
+
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
 
       - name: Download APK from build
         uses: actions/download-artifact@v3
@@ -70,9 +83,14 @@ jobs:
         env:
           BUILD_TOOLS_VERSION: "32.0.0"
 
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
       - name: Upload Release APK
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ steps.previoustag.outputs.tag }}
           files: |
             Olvid.apk
             Olvid-nogoogle.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,8 +22,8 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
-      - name: Run Tests
-        run: cd obv_messenger/ && ./gradlew test --stacktrace
+      # - name: Run Tests
+      #   run: cd obv_messenger/ && ./gradlew test --stacktrace
 
       - name: Build Release APK
         run: cd obv_messenger/ && ./gradlew assembleRelease --stacktrace

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,13 +29,16 @@ jobs:
         run: cd obv_messenger/ && ./gradlew assembleRelease --stacktrace
 
       - name: Rename APK
-        run: mv obv_messenger/app/build/outputs/apk/prod/release/app-prod-release-unsigned.apk Olvid.apk
+        run: |
+          find . -name '*.apk'
+          mv ./obv_messenger/app/build/outputs/apk/prodFull/release/app-prod-full-release-unsigned.apk Olvid.apk
+          mv ./obv_messenger/app/build/outputs/apk/prodNogoogle/release/app-prod-nogoogle-release-unsigned.apk Olvid-nogoogle.apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: apk
-          path: Olvid.apk
+          path: Olvid*.apk
 
   release:
     name: Sign/Release APK
@@ -45,7 +48,7 @@ jobs:
     steps:
 
       - name: Download APK from build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: apk
 
@@ -72,4 +75,6 @@ jobs:
         with:
           files: |
             Olvid.apk
-            ${{steps.sign_app.outputs.signedReleaseFile}}
+            Olvid-nogoogle.apk
+            ${{steps.sign_app.outputs.signedReleaseFile0}}
+            ${{steps.sign_app.outputs.signedReleaseFile1}}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -76,5 +76,5 @@ jobs:
           files: |
             Olvid.apk
             Olvid-nogoogle.apk
-            ${{steps.sign_app.outputs.signedReleaseFile0}}
-            ${{steps.sign_app.outputs.signedReleaseFile1}}
+            Olvid-signed.apk
+            Olvid-nogoogle-signed.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -42,7 +42,7 @@ jobs:
           mv ./obv_messenger/app/build/outputs/apk/prodNogoogle/release/app-prod-nogoogle-release-unsigned.apk Olvid-nogoogle.apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: apk
           path: Olvid*.apk
@@ -68,7 +68,7 @@ jobs:
           echo Last build tool version is: $BUILD_TOOL_VERSION
 
       - name: Download APK from build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: apk
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       # - name: Run Tests
       #   run: cd obv_messenger/ && ./gradlew test --stacktrace
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Sign APK
         uses: r0adkll/sign-android-release@v1

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,70 @@
+name: Rebase and tag
+
+on:
+  workflow_dispatch:
+    # inputs:
+    #   sync_test_mode: # Adds a boolean option that appears during manual workflow run for easy test mode config
+    #     description: 'Test Mode'
+    #     type: boolean
+    #     default: false
+
+jobs:
+  sync_latest_from_upstream:
+    name: Sync latest commits from upstream repo and tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: build-apk
+          fetch-depth: 0
+
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+        with:
+          target_sync_branch: build-apk
+          # REQUIRED 'target_repo_token' exactly like this!
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          target_branch_push_args: '--force'
+          upstream_sync_branch: main
+          upstream_sync_repo: olvid-io/olvid-android
+          upstream_pull_args: '--rebase --tags'
+
+          # Set test_mode true during manual dispatch to run tests instead of the true action!!
+          test_mode: ${{ inputs.sync_test_mode }}
+
+      - name: New commits found
+        if: steps.sync.outputs.has_new_commits == 'true'
+        run: echo "New commits were found to sync."
+
+      - name: No new commits
+        if: steps.sync.outputs.has_new_commits == 'false'
+        run: echo "There were no new commits."
+
+      - name: Show value of 'has_new_commits'
+        run: echo ${{ steps.sync.outputs.has_new_commits }}
+
+      - name: 'Get Previous tag'
+        if: steps.sync.outputs.has_new_commits == 'true'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
+      - name: Bump version and push tag
+        if: steps.sync.outputs.has_new_commits == 'true'
+        uses: EndBug/latest-tag@latest
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          ref: "${{ steps.previoustag.outputs.tag }}-kumy1"
+
+      - name: Trigger build
+        if: steps.sync.outputs.has_new_commits == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh workflow run android.yml \
+            -R kumy/olvid-android \
+            -F "ref=refs/tags/${{ steps.previoustag.outputs.tag }}-kumy1"


### PR DESCRIPTION
- Fix #3 
- Relates #2 


Here is a GitHub workflow that will run on every branch to build and test the APK, and on tag it also create a release, sign and upload the APK.

It needs some secrets to be added to the repo to sign the release (see https://github.com/marketplace/actions/sign-android-release). it also need the `GITHUB_TOKEN` to have write privileges on the repo.

You can see the result on my repo fork https://github.com/kumy/olvid-android/releases (Using a dumb signing key)

Bests