### PR TITLE
Prefers `_` over `|` for backup checkout on Windows

### DIFF
--- a/obv_messenger/app/src/main/java/io/olvid/messenger/services/BackupCloudProviderService.java
+++ b/obv_messenger/app/src/main/java/io/olvid/messenger/services/BackupCloudProviderService.java
@@ -374,7 +374,7 @@ class GoogleDriveProvider {
                 }
 
                 String deviceUniqueId = SettingsActivity.getAutomaticBackupDeviceUniqueId();
-                String fileName = deviceUniqueId + "|" + BackupCloudProviderService.BACKUP_FILE_NAME_MODEL_PART;
+                String fileName = deviceUniqueId + "_" + BackupCloudProviderService.BACKUP_FILE_NAME_MODEL_PART;
 
                 List<File> fileList = googleDriveService.files().list()
                         .setQ("name = '" + fileName + "' and '" + folderId + "' in parents")
@@ -598,7 +598,7 @@ class WebdavProvider {
                 }
 
                 String deviceUniqueId = SettingsActivity.getAutomaticBackupDeviceUniqueId();
-                String fileName = deviceUniqueId + "|" + BackupCloudProviderService.BACKUP_FILE_NAME_MODEL_PART + BACKUP_FILE_EXTENSION;
+                String fileName = deviceUniqueId + "_" + BackupCloudProviderService.BACKUP_FILE_NAME_MODEL_PART + BACKUP_FILE_EXTENSION;
                 String url = (serverUrl.endsWith("/") ? serverUrl : serverUrl + "/") + URLEncoder.encode(fileName, StandardCharsets.UTF_8.name());
 
                 if (sardine.exists(url)) {


### PR DESCRIPTION
Windows do not allow `|` in filenames, thus Olvid backups cannot be checked out on these platforms. This patch replaces this character by `_`, at the cost of being breaking for already existing backups.

---

Feel free to edit this PR as needed (maybe in a BC way ?).

Thanks, bye 👋