### PR TITLE
Constant time Mac verify

### DIFF
--- a/obv_engine/engine/src/main/java/io/olvid/engine/crypto/MAC.java
+++ b/obv_engine/engine/src/main/java/io/olvid/engine/crypto/MAC.java
@@ -21,7 +21,7 @@ package io.olvid.engine.crypto;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
+import java.security.MessageDigest;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -75,7 +75,7 @@ class MACHmacSha256 implements MAC {
     @Override
     public boolean verify(MACKey key, byte[] bytes, byte[] mac) throws InvalidKeyException {
         byte[] newMac = digest(key, bytes);
-        return Arrays.equals(mac, newMac);
+        return MessageDigest.isEqual(newMac, mac);
     }
 
     @Override


### PR DESCRIPTION
Constant time hmac equality check is a best practice to avoid potential timing attacks. It seems that Arrays.equals does not work in constant time. I think MessageDigest.isEqual is more appropriate in this case.